### PR TITLE
Add PhotoRater portfolio site

### DIFF
--- a/src/_data/client.js
+++ b/src/_data/client.js
@@ -1,6 +1,6 @@
 module.exports = {
-    name: "Code Stitch Web Designs",
-    email: "help@codestitch.app",
+    name: "David Harms",
+    email: "contact@davidharmsportfol.io",
     phoneForTel: "555-779-4407",
     phoneFormatted: "(555) 779-4407",
     address: {
@@ -17,7 +17,7 @@ module.exports = {
         instagram: "https://www.instagram.com/",
     },
     //! Make sure you include the file protocol (e.g. https://) and that NO TRAILING SLASH is included
-    domain: "https://www.example.com",
+    domain: "https://davidharmsportfol.io",
     // Passing the isProduction variable for use in HTML templates
     isProduction: process.env.ELEVENTY_ENV === "PROD",
 };

--- a/src/_includes/sections/footer.html
+++ b/src/_includes/sections/footer.html
@@ -42,6 +42,9 @@
                 <a class="cs-nav-link" href="/blog/">Blog</a>
             </li>
             <li class="cs-nav-li">
+                <a class="cs-nav-link" href="/privacy/">Privacy</a>
+            </li>
+            <li class="cs-nav-li">
                 <a class="cs-nav-link" href="/contact/">Contact</a>
             </li>
         </ul>

--- a/src/_includes/sections/header.html
+++ b/src/_includes/sections/header.html
@@ -56,6 +56,11 @@
                             Blog
                         </a>
                     </li>
+                    <li class="cs-li">
+                        <a href="/privacy/" class="cs-li-link {% if page.url == "/privacy/" %} cs-active {% endif %}">
+                            Privacy
+                        </a>
+                    </li>
                     <li class="cs-li cs-hide-on-desktop">
                         <a href="/contact/" class="cs-li-link {% if page.url == "/contact/" %} cs-active {% endif %}">
                             Contact

--- a/src/content/pages/privacy.html
+++ b/src/content/pages/privacy.html
@@ -1,0 +1,17 @@
+---
+title: "Privacy Policy | PhotoRater"
+description: "Privacy policy for the PhotoRater app and portfolio site"
+permalink: "/privacy/"
+---
+
+{% extends "layouts/base.html" %}
+
+{% block body %}
+<section class="cs-container" id="privacy">
+    <h1>Privacy Policy</h1>
+    <p>This page describes how PhotoRater handles your data. No personal
+    information is collected beyond what is necessary for the app to function.</p>
+    <p>For questions about this policy please reach out to
+    <a href="mailto:{{ client.email }}">{{ client.email }}</a>.</p>
+</section>
+{% endblock %}

--- a/src/index.html
+++ b/src/index.html
@@ -1,6 +1,6 @@
 ---
-title: "Pixel Perfect Websites | Code Stitch Web Designs | Denver, CO"
-description: "Meta description for the page"
+title: "PhotoRater | David Harms Portfolio"
+description: "Learn about the PhotoRater app and explore David's work"
 permalink: "/"
 tags: "sitemap" # content/content.json will make sure that all pages in content/ are marked with a "sitemap" tag, for automatic sitemap generation. As index.html is not in content/, we need to add it here to ensure the root page is included in the sitemap generation
 ---
@@ -35,12 +35,12 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
 
     <section id="hero-143">
         <div class="cs-container">
-            <span class="cs-topper">CodeStitch Presents</span>
-            <h1 class="cs-title">The Intermediate Website Kit (SASS)</h1>
+            <span class="cs-topper">Welcome to PhotoRater</span>
+            <h1 class="cs-title">Rate Your Photos Instantly</h1>
             <p class="cs-text">
-                Building faster websites, faster. Just clone, update _data/client.js, swap out some sections, and away you go!
+                PhotoRater uses on-device intelligence to score your pictures and help you choose the best shot.
             </p>
-            <a href="/contact/" class="cs-button-solid">Get in Touch</a>
+            <a href="#" class="cs-button-solid">Download on the App Store</a>
         </div>
 
         <!-- Background Image -->
@@ -233,8 +233,8 @@ tags: "sitemap" # content/content.json will make sure that all pages in content/
     <section id="gallery-48">
         <div class="cs-container">
             <div class="cs-content">
-                <span class="cs-topper">Our Portfolio</span>
-                <h2 class="cs-title">Et orci volutpat, back up generator installations</h2>
+                <span class="cs-topper">Other Projects</span>
+                <h2 class="cs-title">Explore more of my work</h2>
             </div>
             <div class="cs-image-group">
                 <div class="cs-row cs-row-1">


### PR DESCRIPTION
## Summary
- set client details and domain
- add privacy policy page for Apple compliance
- link privacy policy in navigation and footer
- highlight PhotoRater and portfolio on the home page

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688a731526b8833397b4f4f236fc52d1